### PR TITLE
Support phases and optional dependencies

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,7 @@
     "jest/globals": true
   },
   "rules": {
+    "import/no-extraneous-dependencies": "off",
     "jest/no-disabled-tests": "error",
     "jest/no-focused-tests": "error",
     "jest/no-identical-title": "error"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
 All contributions to this repository are more than welcome and appreciated a lot 🎉
-Don't hesitate to [create a new issue](https://github.com/cyrilwanner/next-compose-plugins/issues/new) if you have any question. 
+Don't hesitate to [create a new issue](https://github.com/cyrilwanner/next-compose-plugins/issues/new) if you have any question.
 
 ## Setup instructions
 
@@ -18,6 +18,7 @@ We write tests for all major functionality of this plugin to ensure a good code 
 Please update and/or write new tests when contributing to this repository.
 
 You can run the tests locally with `npm test`.
+To watch for code changes and automatically run tests on changes, use `npm run test:watch` (babel needs to be started in watching mode too for this in a separate process with `npm run watch`).
 Please note that test will get executed against the built sources, so make sure you are either watching the files or build them once (`npm run build`) before running the tests.
 
 ## Coding style

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint src",
     "lint:fix": "eslint --fix src",
     "test": "jest --coverage lib",
+    "test:watch": "jest --watch lib",
     "prepack": "rimraf lib/**/__tests__"
   },
   "repository": {

--- a/src/__tests__/compose.test.js
+++ b/src/__tests__/compose.test.js
@@ -336,4 +336,23 @@ describe('next-compose-plugins/compose', () => {
     expect(plugin1).toHaveBeenCalledTimes(1);
     expect(plugin2).toHaveBeenCalledTimes(0);
   });
+
+  it('handles objects as plugins', () => {
+    const plugin = {
+      plugin1Config: 'foo',
+    };
+
+    const result = composePlugins(PHASE_DEVELOPMENT_SERVER, [plugin], { initial: 'config' });
+
+    expect(result).toEqual({
+      initial: 'config',
+      plugin1Config: 'foo',
+    });
+  });
+
+  it('throws an error for incompatible plugins', () => {
+    const plugin = ['something', 'weird'];
+
+    expect(() => composePlugins(PHASE_DEVELOPMENT_SERVER, [plugin], {})).toThrowError('Incompatible plugin');
+  });
 });

--- a/src/__tests__/compose.test.js
+++ b/src/__tests__/compose.test.js
@@ -1,5 +1,5 @@
 import 'jest';
-import { parsePluginConfig } from '../compose';
+import { parsePluginConfig, composePlugins } from '../compose';
 
 const testPlugin = { test: 'plugin' };
 
@@ -64,7 +64,224 @@ describe('next-compose-plugins/compose', () => {
    *
    * ----------------------------------------------------
    */
-  it('composePlugins just works', () => {
-    // todo: actually test if it really works :)
+  it('passed down the initial configuration', () => {
+    const plugin = jest.fn((nextConfig) => {
+      expect(nextConfig).toEqual({ initial: 'config' });
+
+      return nextConfig;
+    });
+
+    const result = composePlugins(PHASE_DEVELOPMENT_SERVER, [plugin], { initial: 'config' });
+
+    expect(result).toEqual({ initial: 'config' });
+    expect(plugin).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not execute a plugin if it is not in the correct phase', () => {
+    const plugin1 = jest.fn(nextConfig => ({ ...nextConfig, plugin1: true }));
+    const plugin2 = jest.fn(nextConfig => ({ ...nextConfig, plugin2: true }));
+    const plugin3 = jest.fn(nextConfig => ({ ...nextConfig, plugin3: true }));
+
+    const result = composePlugins(PHASE_DEVELOPMENT_SERVER, [
+      [plugin1, [PHASE_DEVELOPMENT_SERVER, PHASE_PRODUCTION_BUILD]],
+      [plugin2, [PHASE_PRODUCTION_BUILD]],
+      [plugin3, ['!', PHASE_PRODUCTION_SERVER]],
+    ], { initial: 'config' });
+
+    expect(result).toEqual({
+      initial: 'config',
+      plugin1: true,
+      plugin3: true,
+    });
+
+    expect(plugin1).toHaveBeenCalledTimes(1);
+    expect(plugin2).toHaveBeenCalledTimes(0);
+    expect(plugin3).toHaveBeenCalledTimes(1);
+  });
+
+  it('merges the plugin configuration', () => {
+    const plugin1 = jest.fn((nextConfig) => {
+      expect(nextConfig.plugin1Config).toEqual('bar');
+
+      return nextConfig;
+    });
+
+    const plugin2 = jest.fn((nextConfig) => {
+      expect(nextConfig.plugin2Config).toEqual({ hello: 'world' });
+
+      return nextConfig;
+    });
+
+    const plugin3 = jest.fn((nextConfig) => {
+      expect(nextConfig.plugin3Config).toEqual(false);
+
+      return nextConfig;
+    });
+
+    composePlugins(PHASE_DEVELOPMENT_SERVER, [
+      [plugin1, {
+        plugin1Config: 'bar',
+        [PHASE_PRODUCTION_SERVER]: {
+          plugin1Config: 'foo',
+        },
+      }],
+      [plugin2, {
+        plugin2Config: { hey: 'you' },
+        [PHASE_DEVELOPMENT_SERVER]: {
+          plugin2Config: { hello: 'world' },
+        },
+      }],
+      [plugin3, {
+        plugin3Config: true,
+        [PHASE_PRODUCTION_BUILD + PHASE_DEVELOPMENT_SERVER]: {
+          plugin3Config: false,
+        },
+      }],
+    ], {});
+
+    expect(plugin1).toHaveBeenCalledTimes(1);
+    expect(plugin2).toHaveBeenCalledTimes(1);
+    expect(plugin3).toHaveBeenCalledTimes(1);
+  });
+
+  it('provides next-compose-plugin infos for plugins', () => {
+    const plugin = jest.fn((nextConfig, info) => {
+      expect(info).toEqual({
+        nextComposePlugins: true,
+        phase: PHASE_DEVELOPMENT_SERVER,
+      });
+
+      return nextConfig;
+    });
+
+    composePlugins(PHASE_DEVELOPMENT_SERVER, [plugin], {});
+
+    expect(plugin).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not pass down the updated configuration if it is in the wrong phase', () => {
+    const plugin1 = jest.fn(nextConfig => ({
+      ...nextConfig,
+      plugin1Config: 'foo',
+      phases: [PHASE_DEVELOPMENT_SERVER, PHASE_PRODUCTION_BUILD],
+    }));
+
+    const plugin2 = jest.fn(nextConfig => ({
+      ...nextConfig,
+      plugin2Config: 'bar',
+      webpack: () => `changed ${nextConfig.webpack()}`,
+      phases: [PHASE_DEVELOPMENT_SERVER],
+    }));
+
+    const plugin3 = jest.fn(nextConfig => ({
+      ...nextConfig,
+      plugin3Config: 'world',
+    }));
+
+    const webpackConfig = () => 'initial webpack config';
+
+    const result = composePlugins(PHASE_PRODUCTION_BUILD, [plugin1, plugin2, plugin3], {
+      initial: 'config',
+      webpack: webpackConfig,
+    });
+
+    expect(result).toEqual({
+      initial: 'config',
+      plugin1Config: 'foo',
+      plugin3Config: 'world',
+      webpack: webpackConfig,
+    });
+
+    expect(result.webpack()).toEqual('initial webpack config');
+
+    expect(plugin1).toHaveBeenCalledTimes(1);
+    expect(plugin2).toHaveBeenCalledTimes(1);
+    expect(plugin3).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets the user overwrite the plugins phase', () => {
+    const plugin1 = jest.fn(nextConfig => ({
+      ...nextConfig,
+      plugin1Config: 'foo',
+      phases: [PHASE_DEVELOPMENT_SERVER, PHASE_PRODUCTION_BUILD],
+    }));
+
+    const plugin2 = jest.fn(nextConfig => ({
+      ...nextConfig,
+      plugin2Config: 'bar',
+      phases: [PHASE_DEVELOPMENT_SERVER],
+    }));
+
+    const result = composePlugins(PHASE_PRODUCTION_BUILD, [plugin1, [plugin2, [PHASE_PRODUCTION_BUILD]]], { initial: 'config' });
+
+    expect(result).toEqual({
+      initial: 'config',
+      plugin1Config: 'foo',
+      plugin2Config: 'bar',
+    });
+
+    expect(plugin1).toHaveBeenCalledTimes(1);
+    expect(plugin2).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not pass down the phase configuration of the previous plugin', () => {
+    const plugin1 = jest.fn(({ plugin1Config, ...nextConfig }) => {
+      expect(nextConfig).toEqual({ initial: 'config' });
+      expect(plugin1Config).toEqual('foo');
+
+      return nextConfig;
+    });
+
+    const plugin2 = jest.fn(({ plugin2Config, ...nextConfig }) => {
+      expect(nextConfig).toEqual({ initial: 'config' });
+      expect(plugin2Config).toEqual('bar');
+
+      return nextConfig;
+    });
+
+    const result = composePlugins(PHASE_DEVELOPMENT_SERVER, [
+      [plugin1, { plugin1Config: 'foo' }],
+      [plugin2, { plugin2Config: 'bar' }],
+    ], { initial: 'config' });
+
+    expect(result).toEqual({ initial: 'config' });
+
+    expect(plugin1).toHaveBeenCalledTimes(1);
+    expect(plugin2).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not change a reference but always creates new objects', () => {
+    const plugin1 = jest.fn(nextConfig => ({
+      ...nextConfig,
+      plugin1Config: 'foo',
+      phases: [PHASE_DEVELOPMENT_SERVER, PHASE_PRODUCTION_BUILD],
+    }));
+
+    const plugin2 = jest.fn((nextConfig) => {
+      nextConfig.illegallyUpdated = true; // eslint-disable-line no-param-reassign
+
+      return {
+        ...nextConfig,
+        plugin2Config: 'bar',
+        phases: [PHASE_DEVELOPMENT_SERVER],
+      };
+    });
+
+    const plugin3 = jest.fn(nextConfig => ({
+      ...nextConfig,
+      plugin3Config: 'world',
+    }));
+
+    const result = composePlugins(PHASE_PRODUCTION_BUILD, [plugin1, plugin2, plugin3], { initial: 'config' });
+
+    expect(result).toEqual({
+      initial: 'config',
+      plugin1Config: 'foo',
+      plugin3Config: 'world',
+    });
+
+    expect(plugin1).toHaveBeenCalledTimes(1);
+    expect(plugin2).toHaveBeenCalledTimes(1);
+    expect(plugin3).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/__tests__/compose.test.js
+++ b/src/__tests__/compose.test.js
@@ -1,0 +1,70 @@
+import 'jest';
+import { parsePluginConfig } from '../compose';
+
+const testPlugin = { test: 'plugin' };
+
+const PHASE_DEVELOPMENT_SERVER = 'phase-development-server';
+const PHASE_PRODUCTION_SERVER = 'phase-production-server';
+const PHASE_PRODUCTION_BUILD = 'phase-production-build';
+
+describe('next-compose-plugins/compose', () => {
+  /**
+   * parsePluginConfig
+   *
+   * ----------------------------------------------------
+   */
+  it('parses the plugin without a configuration', () => {
+    const withoutConfig1 = parsePluginConfig(testPlugin);
+    expect(withoutConfig1).toEqual({
+      pluginFunction: { test: 'plugin' },
+      pluginConfig: {},
+      phases: null,
+    });
+    expect(withoutConfig1.pluginFunction).toBe(testPlugin); // test same reference
+
+    const withoutConfig2 = parsePluginConfig([testPlugin]);
+    expect(withoutConfig2).toEqual({
+      pluginFunction: { test: 'plugin' },
+      pluginConfig: {},
+      phases: null,
+    });
+    expect(withoutConfig2.pluginFunction).toBe(testPlugin);
+  });
+
+  it('parses the plugin with a configuration', () => {
+    const withConfig = parsePluginConfig([testPlugin, { my: 'conf', nested: { foo: 'bar' } }]);
+
+    expect(withConfig).toEqual({
+      pluginFunction: { test: 'plugin' },
+      pluginConfig: { my: 'conf', nested: { foo: 'bar' } },
+      phases: null,
+    });
+
+    expect(withConfig.pluginFunction).toBe(testPlugin);
+  });
+
+  it('parses the plugin with a phase restriction', () => {
+    const withPhaseRestriction = parsePluginConfig([testPlugin, [
+      PHASE_DEVELOPMENT_SERVER,
+      PHASE_PRODUCTION_BUILD,
+      PHASE_PRODUCTION_SERVER,
+    ]]);
+
+    expect(withPhaseRestriction).toEqual({
+      pluginFunction: { test: 'plugin' },
+      pluginConfig: {},
+      phases: [PHASE_DEVELOPMENT_SERVER, PHASE_PRODUCTION_BUILD, PHASE_PRODUCTION_SERVER],
+    });
+
+    expect(withPhaseRestriction.pluginFunction).toBe(testPlugin);
+  });
+
+  /**
+   * composePlugins
+   *
+   * ----------------------------------------------------
+   */
+  it('composePlugins just works', () => {
+    // todo: actually test if it really works :)
+  });
+});

--- a/src/__tests__/optional.test.js
+++ b/src/__tests__/optional.test.js
@@ -1,0 +1,47 @@
+import 'jest';
+import { markOptional, isOptional, resolveOptionalPlugin, OPTIONAL_SYMBOL } from '../optional';
+
+describe('next-compose-plugins/optional', () => {
+  /**
+   * markOptional
+   *
+   * -------------------------------------
+   */
+  it('marks a plugin as optional', () => {
+    const plugin = jest.fn(() => 'my-plugin');
+
+    markOptional(plugin);
+
+    expect(plugin[OPTIONAL_SYMBOL]).toEqual(true);
+    expect(plugin).not.toHaveBeenCalled();
+  });
+
+  /**
+   * isOptional
+   *
+   * -----------------------------------------
+   */
+  it('checks if a plugin is optional', () => {
+    const plugin = jest.fn(() => 'my-plugin');
+
+    expect(isOptional(plugin)).toEqual(false);
+
+    markOptional(plugin);
+
+    expect(isOptional(plugin)).toEqual(true);
+    expect(plugin).not.toHaveBeenCalled();
+  });
+
+  /**
+   * resolveOptionalPlugin
+   *
+   * --------------------------------------
+   */
+  it('resolves an optional plugin', () => {
+    const plugin = jest.fn(() => 'my-plugin');
+
+    expect(plugin).not.toHaveBeenCalled();
+    expect(resolveOptionalPlugin(plugin)).toEqual('my-plugin');
+    expect(plugin).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/phases.test.js
+++ b/src/__tests__/phases.test.js
@@ -1,0 +1,156 @@
+import 'jest';
+import { needsPhases, isInCurrentPhase, mergePhaseConfiguration } from '../phases';
+
+const testPlugin = {};
+
+const PHASE_DEVELOPMENT_SERVER = 'phase-development-server';
+const PHASE_PRODUCTION_SERVER = 'phase-production-server';
+const PHASE_PRODUCTION_BUILD = 'phase-production-build';
+
+describe('next-compose-plugins/phases', () => {
+  it('detects if a configuration needs phases', () => {
+    expect(needsPhases([[testPlugin, { my: 'conf' }, [PHASE_DEVELOPMENT_SERVER]]])).toEqual(true);
+    expect(needsPhases([[testPlugin, [PHASE_DEVELOPMENT_SERVER]]])).toEqual(true);
+    expect(needsPhases([[testPlugin, { [PHASE_DEVELOPMENT_SERVER]: { my: 'conf' } }]])).toEqual(true);
+    expect(needsPhases([[testPlugin], [testPlugin, { my: 'conf' }, [PHASE_DEVELOPMENT_SERVER]]])).toEqual(true);
+    expect(needsPhases([[testPlugin, { my: 'conf' }, [PHASE_DEVELOPMENT_SERVER]]], [testPlugin])).toEqual(true);
+  });
+
+  it('detects if a configuration does not need phases', () => {
+    expect(needsPhases([testPlugin])).toEqual(false);
+    expect(needsPhases([[testPlugin]])).toEqual(false);
+    expect(needsPhases([[testPlugin, { my: 'conf' }]])).toEqual(false);
+    expect(needsPhases([testPlugin, [testPlugin, {}]])).toEqual(false);
+    expect(needsPhases([[testPlugin, {}], testPlugin])).toEqual(false);
+  });
+
+  it('checks when a plugin should get applied in the current phase', () => {
+    // check array syntax
+    expect(isInCurrentPhase(PHASE_DEVELOPMENT_SERVER, [PHASE_DEVELOPMENT_SERVER])).toEqual(true);
+    expect(isInCurrentPhase(PHASE_DEVELOPMENT_SERVER, [
+      PHASE_PRODUCTION_SERVER,
+      PHASE_DEVELOPMENT_SERVER,
+    ])).toEqual(true);
+    expect(isInCurrentPhase(PHASE_DEVELOPMENT_SERVER, [
+      PHASE_DEVELOPMENT_SERVER,
+      PHASE_PRODUCTION_SERVER,
+    ])).toEqual(true);
+
+    // check string syntax
+    expect(isInCurrentPhase(PHASE_DEVELOPMENT_SERVER, PHASE_DEVELOPMENT_SERVER)).toEqual(true);
+    expect(isInCurrentPhase(PHASE_DEVELOPMENT_SERVER, PHASE_DEVELOPMENT_SERVER +
+      PHASE_PRODUCTION_SERVER)).toEqual(true);
+    expect(isInCurrentPhase(PHASE_DEVELOPMENT_SERVER, PHASE_PRODUCTION_SERVER +
+      PHASE_DEVELOPMENT_SERVER)).toEqual(true);
+  });
+
+  it('checks when a plugin should not get applied in the current phase', () => {
+    // check array syntax
+    expect(isInCurrentPhase(PHASE_PRODUCTION_BUILD, [PHASE_DEVELOPMENT_SERVER])).toEqual(false);
+    expect(isInCurrentPhase(PHASE_PRODUCTION_BUILD, [
+      PHASE_PRODUCTION_SERVER,
+      PHASE_DEVELOPMENT_SERVER,
+    ])).toEqual(false);
+    expect(isInCurrentPhase(PHASE_PRODUCTION_BUILD, [
+      PHASE_DEVELOPMENT_SERVER,
+      PHASE_PRODUCTION_SERVER,
+    ])).toEqual(false);
+
+    // check string syntax
+    expect(isInCurrentPhase(PHASE_PRODUCTION_BUILD, PHASE_DEVELOPMENT_SERVER)).toEqual(false);
+    expect(isInCurrentPhase(PHASE_PRODUCTION_BUILD, PHASE_DEVELOPMENT_SERVER +
+      PHASE_PRODUCTION_SERVER)).toEqual(false);
+    expect(isInCurrentPhase(PHASE_PRODUCTION_BUILD, PHASE_PRODUCTION_SERVER +
+      PHASE_DEVELOPMENT_SERVER)).toEqual(false);
+  });
+
+  it('checks when a plugin should get applied in the current phase with a negated config', () => {
+    // check array syntax
+    expect(isInCurrentPhase(PHASE_DEVELOPMENT_SERVER, ['!', PHASE_PRODUCTION_SERVER])).toEqual(true);
+    expect(isInCurrentPhase(PHASE_DEVELOPMENT_SERVER, [
+      '!',
+      PHASE_PRODUCTION_SERVER,
+      PHASE_PRODUCTION_BUILD,
+    ])).toEqual(true);
+
+    // check string syntax
+    expect(isInCurrentPhase(PHASE_DEVELOPMENT_SERVER, `!${PHASE_PRODUCTION_SERVER}`)).toEqual(true);
+    expect(isInCurrentPhase(PHASE_DEVELOPMENT_SERVER, `!${PHASE_PRODUCTION_SERVER}${PHASE_PRODUCTION_BUILD}`)).toEqual(true);
+  });
+
+  it('checks when a plugin should not get applied in the current phase with a negated config', () => {
+    // check array syntax
+    expect(isInCurrentPhase(PHASE_PRODUCTION_BUILD, ['!', PHASE_PRODUCTION_BUILD])).toEqual(false);
+    expect(isInCurrentPhase(PHASE_PRODUCTION_BUILD, [
+      '!',
+      PHASE_PRODUCTION_BUILD,
+      PHASE_DEVELOPMENT_SERVER,
+    ])).toEqual(false);
+    expect(isInCurrentPhase(PHASE_PRODUCTION_BUILD, [
+      '!',
+      PHASE_DEVELOPMENT_SERVER,
+      PHASE_PRODUCTION_BUILD,
+    ])).toEqual(false);
+
+    // check string syntax
+    expect(isInCurrentPhase(PHASE_PRODUCTION_BUILD, `!${PHASE_PRODUCTION_BUILD}`)).toEqual(false);
+    expect(isInCurrentPhase(PHASE_PRODUCTION_BUILD, `!${PHASE_DEVELOPMENT_SERVER}${PHASE_PRODUCTION_BUILD}`)).toEqual(false);
+    expect(isInCurrentPhase(PHASE_PRODUCTION_BUILD, `!${PHASE_PRODUCTION_BUILD}${PHASE_DEVELOPMENT_SERVER}`)).toEqual(false);
+  });
+
+  it('merges phase specific configuration', () => {
+    const pluginConfig = {
+      build: 'default-build',
+      cssModules: true,
+      nested: {
+        conf: true,
+      },
+    };
+
+    const devMerged = mergePhaseConfiguration(PHASE_DEVELOPMENT_SERVER, {
+      ...pluginConfig,
+      [PHASE_DEVELOPMENT_SERVER]: {
+        build: 'dev-build',
+      },
+      [PHASE_PRODUCTION_BUILD + PHASE_PRODUCTION_SERVER]: {
+        build: 'prod-build',
+        nested: {
+          conf: false,
+        },
+      },
+    });
+
+    expect(devMerged).toMatchObject({
+      build: 'dev-build',
+      cssModules: true,
+      nested: {
+        conf: true,
+      },
+    });
+    expect(Object.keys(devMerged)).not.toContain(PHASE_DEVELOPMENT_SERVER);
+    expect(Object.keys(devMerged)).not.toContain(PHASE_PRODUCTION_SERVER);
+
+    const prodMerged = mergePhaseConfiguration(PHASE_PRODUCTION_SERVER, {
+      ...pluginConfig,
+      [PHASE_DEVELOPMENT_SERVER]: {
+        build: 'dev-build',
+      },
+      [PHASE_PRODUCTION_BUILD + PHASE_PRODUCTION_SERVER]: {
+        build: 'prod-build',
+        nested: {
+          conf: false,
+        },
+      },
+    });
+
+    expect(prodMerged).toMatchObject({
+      build: 'prod-build',
+      cssModules: true,
+      nested: {
+        conf: false,
+      },
+    });
+    expect(Object.keys(prodMerged)).not.toContain(PHASE_DEVELOPMENT_SERVER);
+    expect(Object.keys(prodMerged)).not.toContain(PHASE_PRODUCTION_SERVER);
+  });
+});

--- a/src/__tests__/phases.test.js
+++ b/src/__tests__/phases.test.js
@@ -1,29 +1,16 @@
 import 'jest';
-import { needsPhases, isInCurrentPhase, mergePhaseConfiguration } from '../phases';
-
-const testPlugin = {};
+import { isInCurrentPhase, mergePhaseConfiguration } from '../phases';
 
 const PHASE_DEVELOPMENT_SERVER = 'phase-development-server';
 const PHASE_PRODUCTION_SERVER = 'phase-production-server';
 const PHASE_PRODUCTION_BUILD = 'phase-production-build';
 
 describe('next-compose-plugins/phases', () => {
-  it('detects if a configuration needs phases', () => {
-    expect(needsPhases([[testPlugin, { my: 'conf' }, [PHASE_DEVELOPMENT_SERVER]]])).toEqual(true);
-    expect(needsPhases([[testPlugin, [PHASE_DEVELOPMENT_SERVER]]])).toEqual(true);
-    expect(needsPhases([[testPlugin, { [PHASE_DEVELOPMENT_SERVER]: { my: 'conf' } }]])).toEqual(true);
-    expect(needsPhases([[testPlugin], [testPlugin, { my: 'conf' }, [PHASE_DEVELOPMENT_SERVER]]])).toEqual(true);
-    expect(needsPhases([[testPlugin, { my: 'conf' }, [PHASE_DEVELOPMENT_SERVER]]], [testPlugin])).toEqual(true);
-  });
-
-  it('detects if a configuration does not need phases', () => {
-    expect(needsPhases([testPlugin])).toEqual(false);
-    expect(needsPhases([[testPlugin]])).toEqual(false);
-    expect(needsPhases([[testPlugin, { my: 'conf' }]])).toEqual(false);
-    expect(needsPhases([testPlugin, [testPlugin, {}]])).toEqual(false);
-    expect(needsPhases([[testPlugin, {}], testPlugin])).toEqual(false);
-  });
-
+  /**
+   * isInCurrentPhase
+   *
+   * -----------------------------------------------------------------------
+   */
   it('checks when a plugin should get applied in the current phase', () => {
     // check array syntax
     expect(isInCurrentPhase(PHASE_DEVELOPMENT_SERVER, [PHASE_DEVELOPMENT_SERVER])).toEqual(true);
@@ -98,6 +85,11 @@ describe('next-compose-plugins/phases', () => {
     expect(isInCurrentPhase(PHASE_PRODUCTION_BUILD, `!${PHASE_PRODUCTION_BUILD}${PHASE_DEVELOPMENT_SERVER}`)).toEqual(false);
   });
 
+  /**
+   * mergePhaseConfiguration
+   *
+   * ----------------------------------------------
+   */
   it('merges phase specific configuration', () => {
     const pluginConfig = {
       build: 'default-build',
@@ -106,6 +98,29 @@ describe('next-compose-plugins/phases', () => {
         conf: true,
       },
     };
+
+    const nothingMerged = mergePhaseConfiguration(PHASE_PRODUCTION_SERVER, {
+      ...pluginConfig,
+      [PHASE_DEVELOPMENT_SERVER]: {
+        build: 'dev-build',
+      },
+      [PHASE_PRODUCTION_BUILD]: {
+        build: 'prod-build',
+        nested: {
+          conf: false,
+        },
+      },
+    });
+
+    expect(nothingMerged).toEqual({
+      build: 'default-build',
+      cssModules: true,
+      nested: {
+        conf: true,
+      },
+    });
+    expect(Object.keys(nothingMerged)).not.toContain(PHASE_DEVELOPMENT_SERVER);
+    expect(Object.keys(nothingMerged)).not.toContain(PHASE_PRODUCTION_SERVER);
 
     const devMerged = mergePhaseConfiguration(PHASE_DEVELOPMENT_SERVER, {
       ...pluginConfig,
@@ -120,7 +135,7 @@ describe('next-compose-plugins/phases', () => {
       },
     });
 
-    expect(devMerged).toMatchObject({
+    expect(devMerged).toEqual({
       build: 'dev-build',
       cssModules: true,
       nested: {
@@ -143,7 +158,7 @@ describe('next-compose-plugins/phases', () => {
       },
     });
 
-    expect(prodMerged).toMatchObject({
+    expect(prodMerged).toEqual({
       build: 'prod-build',
       cssModules: true,
       nested: {

--- a/src/compose.js
+++ b/src/compose.js
@@ -77,10 +77,18 @@ export const composePlugins = (phase, plugins, initialConfig) => {
     }
 
     const mergedPluginConfig = mergePhaseConfiguration(phase, pluginConfig);
-    const updatedConfig = resolvedPlugin({
-      ...config,
-      ...mergedPluginConfig,
-    }, nextComposePluginsParam);
+    let updatedConfig;
+
+    if (typeof resolvedPlugin === 'function') {
+      updatedConfig = resolvedPlugin({
+        ...config,
+        ...mergedPluginConfig,
+      }, nextComposePluginsParam);
+    } else if (typeof resolvedPlugin === 'object') {
+      updatedConfig = resolvedPlugin;
+    } else {
+      throw new Error('Incompatible plugin: plugin needs to export either a function or an object!');
+    }
 
     // check if the plugin itself has defined in phases it should run
     // and the user did not overwrite it

--- a/src/compose.js
+++ b/src/compose.js
@@ -1,4 +1,5 @@
 import { isInCurrentPhase, mergePhaseConfiguration } from './phases';
+import { isOptional, resolveOptionalPlugin } from './optional';
 
 /**
  * Plugins can be added to `withPlugins` in multiple ways.
@@ -69,8 +70,14 @@ export const composePlugins = (phase, plugins, initialConfig) => {
       }
     }
 
+    let resolvedPlugin = pluginFunction;
+
+    if (isOptional(pluginFunction)) {
+      resolvedPlugin = resolveOptionalPlugin(pluginFunction);
+    }
+
     const mergedPluginConfig = mergePhaseConfiguration(phase, pluginConfig);
-    const updatedConfig = pluginFunction({
+    const updatedConfig = resolvedPlugin({
       ...config,
       ...mergedPluginConfig,
     }, nextComposePluginsParam);

--- a/src/compose.js
+++ b/src/compose.js
@@ -1,0 +1,96 @@
+import { isInCurrentPhase, mergePhaseConfiguration } from './phases';
+
+/**
+ * Plugins can be added to `withPlugins` in multiple ways.
+ * All possibilities are handled here and returned in a standardized way.
+ *
+ * @param {array|function} plugin - plugin configuration
+ */
+export const parsePluginConfig = (plugin) => {
+  // it can only depend on phases if it has specific configuration
+  if (plugin instanceof Array) {
+    // if the plugin array contains 3 values, it always depends on phases
+    // [plugin: function, config: object, phases: array]
+    if (plugin.length > 2) {
+      return {
+        pluginFunction: plugin[0],
+        pluginConfig: plugin[1],
+        phases: plugin[2],
+      };
+    }
+
+    // if the plugin array contains 2 values and the second one is an array, it depends on phases
+    // [plugin: function, phases: array]
+    if (plugin.length > 1 && plugin[1] instanceof Array) {
+      return {
+        pluginFunction: plugin[0],
+        pluginConfig: {},
+        phases: plugin[1],
+      };
+    }
+
+    // plugin does not contain phase specific config but could have plugin configuration
+    // [plugin: function, config?: object]
+    return {
+      pluginFunction: plugin[0],
+      pluginConfig: plugin[1] || {},
+      phases: null,
+    };
+  }
+
+  return {
+    pluginFunction: plugin,
+    pluginConfig: {},
+    phases: null,
+  };
+};
+
+/**
+ * Composes all plugins
+ *
+ * @param {string} phase - current phase
+ * @param {array} plugins - all plugins
+ * @param {object} initialConfig - initial configuration
+ */
+export const composePlugins = (phase, plugins, initialConfig) => {
+  const nextComposePluginsParam = {
+    nextComposePlugins: true,
+    phase,
+  };
+  let config = { ...initialConfig };
+
+  plugins.forEach((plugin) => {
+    const { pluginFunction, pluginConfig, phases } = parsePluginConfig(plugin);
+
+    // check if the plugin should not get executed in the current phase
+    if (phases !== null) {
+      if (!isInCurrentPhase(phase, phases)) {
+        return;
+      }
+    }
+
+    const mergedPluginConfig = mergePhaseConfiguration(phase, pluginConfig);
+    const updatedConfig = pluginFunction({
+      ...config,
+      mergedPluginConfig,
+    }, nextComposePluginsParam);
+
+    // check if the plugin itself has defined in phases it should run
+    // and the user did not overwrite it
+    if (phases !== null && updatedConfig.phases) {
+      if (!isInCurrentPhase(phase, updatedConfig.phases)) {
+        return;
+      }
+    }
+
+    // delete plugin specific phases array so it doesn't propagate to the next plugin
+    if (updatedConfig.phases) {
+      delete updatedConfig.phases;
+    }
+
+    // merge config back to the main one
+    config = { ...config, ...updatedConfig };
+  });
+
+  return config;
+};

--- a/src/compose.js
+++ b/src/compose.js
@@ -72,12 +72,12 @@ export const composePlugins = (phase, plugins, initialConfig) => {
     const mergedPluginConfig = mergePhaseConfiguration(phase, pluginConfig);
     const updatedConfig = pluginFunction({
       ...config,
-      mergedPluginConfig,
+      ...mergedPluginConfig,
     }, nextComposePluginsParam);
 
     // check if the plugin itself has defined in phases it should run
     // and the user did not overwrite it
-    if (phases !== null && updatedConfig.phases) {
+    if (phases === null && updatedConfig.phases) {
       if (!isInCurrentPhase(phase, updatedConfig.phases)) {
         return;
       }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import { composePlugins } from './compose';
+import { markOptional } from './optional';
 
 /**
  * Composes all plugins together.
@@ -15,8 +16,6 @@ export const withPlugins = ([...plugins], nextConfig = {}) => (phase, { defaultC
   return composePlugins(phase, plugins, config);
 };
 
-export const optional = () => {
-  // todo
-};
+export const optional = markOptional;
 
 export default withPlugins;

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,9 @@
-module.exports = ([...plugins], nextConfig = {}) => {
-  let config = { ...nextConfig };
-
-  plugins.forEach((plugin) => {
-    if (plugin instanceof Array) {
-      const [initPlugin, pluginConfig] = plugin;
-      config = initPlugin({ ...config, ...(pluginConfig || {}) });
-    } else {
-      config = plugin(config);
-    }
-  });
-
-  return config;
+export const withPlugins = ([...plugins], nextConfig = {}) => {
+  // todo
 };
+
+export const optional = (plugin) => {
+  // todo
+};
+
+export default withPlugins;

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,21 @@
-export const withPlugins = ([...plugins], nextConfig = {}) => {
-  // todo
+import { composePlugins } from './compose';
+
+/**
+ * Composes all plugins together.
+ *
+ * @param {array} plugins - all plugins to load and initialize
+ * @param {object} nextConfig - direct configuration for next.js (optional)
+ */
+export const withPlugins = ([...plugins], nextConfig = {}) => (phase, { defaultConfig }) => {
+  const config = {
+    ...defaultConfig,
+    ...nextConfig,
+  };
+
+  return composePlugins(phase, plugins, config);
 };
 
-export const optional = (plugin) => {
+export const optional = () => {
   // todo
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import { markOptional } from './optional';
  * @param {array} plugins - all plugins to load and initialize
  * @param {object} nextConfig - direct configuration for next.js (optional)
  */
-export const withPlugins = ([...plugins], nextConfig = {}) => (phase, { defaultConfig }) => {
+const withPlugins = ([...plugins], nextConfig = {}) => (phase, { defaultConfig }) => {
   const config = {
     ...defaultConfig,
     ...nextConfig,
@@ -16,6 +16,9 @@ export const withPlugins = ([...plugins], nextConfig = {}) => (phase, { defaultC
   return composePlugins(phase, plugins, config);
 };
 
-export const optional = markOptional;
+// define exports
+const exports = withPlugins;
+exports.withPlugins = withPlugins;
+exports.optional = markOptional;
 
-export default withPlugins;
+module.exports = exports;

--- a/src/optional.js
+++ b/src/optional.js
@@ -1,0 +1,26 @@
+export const OPTIONAL_SYMBOL = Symbol('__NEXT_COMPOSE_PLUGINS_OPTIONAL');
+
+/**
+ * Marks a plugin as optional
+ *
+ * @param {function} plugin - function which requires a plugin
+ */
+export const markOptional = (plugin) => {
+  plugin[OPTIONAL_SYMBOL] = true; // eslint-disable-line no-param-reassign
+
+  return plugin;
+};
+
+/**
+ * Check if a plugin has been marked as optional before
+ *
+ * @param {function} plugin - plugin to check
+ */
+export const isOptional = plugin => plugin[OPTIONAL_SYMBOL] === true;
+
+/**
+ * Resolve an optional plugin
+ *
+ * @param {function} plugin - function which requires a plugin
+ */
+export const resolveOptionalPlugin = plugin => plugin();

--- a/src/phases.js
+++ b/src/phases.js
@@ -1,0 +1,79 @@
+/**
+ * Check if at least one of the plugin configuration depends on phases
+ *
+ * @param {array} plugins
+ */
+export const needsPhases = (plugins) => {
+  const res = plugins.some((plugin) => {
+    // if it has no specific config, it can't depend on phases
+    if (!(plugin instanceof Array)) {
+      return false;
+    }
+
+    // if the plugin array contains 3 values, it always depends on phases
+    // [plugin, config, phases]
+    if (plugin.length > 2) {
+      return true;
+    }
+
+    // if the plugin array contains 2 values and the second one is an array, it depends on phases
+    // [plugin, phases]
+    if (plugin.length > 1 && plugin[1] instanceof Array) {
+      return true;
+    }
+
+    // check if there is a phase specific config in the config object
+    // [plugin, config]
+    if (plugin.length > 1) {
+      return Object.keys(plugin[1]).some(value => value.startsWith('phase-'));
+    }
+
+    return false;
+  });
+
+  return res;
+};
+
+/**
+ * Check if the current phase is in the phase config and so a plugin should get applied
+ *
+ * @param {string} currentPhase - current phase
+ * @param {array|string} phaseConfig - phase config in an array ([PHASE1, PHASE2])
+ *                                     or string (PHASE1 + PHASE2)
+ */
+export const isInCurrentPhase = (currentPhase, phaseConfig) => {
+  // phase config can be an array or string, so always convert it to a string
+  const parsedPhaseConfig = phaseConfig instanceof Array ? phaseConfig.join('') : phaseConfig;
+
+  // negate the check
+  if (parsedPhaseConfig.substr(0, 1) === '!') {
+    return parsedPhaseConfig.indexOf(currentPhase) < 0;
+  }
+
+  return parsedPhaseConfig.indexOf(currentPhase) >= 0;
+};
+
+/**
+ * Merge the configuration of a plugin with specific values only applied on the current phase
+ *
+ * @param {string} currentPhase - current phase
+ * @param {object} config - plugin configuration
+ */
+export const mergePhaseConfiguration = (currentPhase, config) => {
+  let mergedConfig = {};
+
+  Object.keys(config).forEach((key) => {
+    if (key.startsWith('phase-') || key.startsWith('!phase-')) {
+      if (isInCurrentPhase(currentPhase, key)) {
+        mergedConfig = {
+          ...mergedConfig,
+          ...config[key],
+        };
+      }
+    } else {
+      mergedConfig[key] = config[key];
+    }
+  });
+
+  return mergedConfig;
+};

--- a/src/phases.js
+++ b/src/phases.js
@@ -1,40 +1,4 @@
 /**
- * Check if at least one of the plugin configuration depends on phases
- *
- * @param {array} plugins
- */
-export const needsPhases = (plugins) => {
-  const res = plugins.some((plugin) => {
-    // if it has no specific config, it can't depend on phases
-    if (!(plugin instanceof Array)) {
-      return false;
-    }
-
-    // if the plugin array contains 3 values, it always depends on phases
-    // [plugin, config, phases]
-    if (plugin.length > 2) {
-      return true;
-    }
-
-    // if the plugin array contains 2 values and the second one is an array, it depends on phases
-    // [plugin, phases]
-    if (plugin.length > 1 && plugin[1] instanceof Array) {
-      return true;
-    }
-
-    // check if there is a phase specific config in the config object
-    // [plugin, config]
-    if (plugin.length > 1) {
-      return Object.keys(plugin[1]).some(value => value.startsWith('phase-'));
-    }
-
-    return false;
-  });
-
-  return res;
-};
-
-/**
  * Check if the current phase is in the phase config and so a plugin should get applied
  *
  * @param {string} currentPhase - current phase


### PR DESCRIPTION
This is a complete rewrite and resolves #2.
It should get released as `v2.0.0` because there are breaking changes and it requires next.js `v5.1.x` as it depends on features introduced in this version.

* Supports phases
  * Plugins can only be added in specific phases or excluded from phases
  * Configuration can get overwritten for specific phases
* Adds an optional helper to only load a plugin in a specific phase
* Plugins can specify by their own in which phases they should get loaded